### PR TITLE
[CI] format ignore assets

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 docs/
+assets/


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added the `assets/` directory to `.prettierignore` to exclude it from Prettier formatting.

### Why are the changes needed?
To prevent Prettier from automatically formatting files within the assets directory, maintaining their original formatting.

### Does this PR introduce _any_ user-facing change?
No

### How was this patch tested?
Verified that Prettier ignores files in the assets directory when running formatting commands.