### PR TITLE
Contributors altt

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,5 +73,7 @@ Further details can be found in the [Architecture Overview](https://docs.digimon
 ## Contributors
 
 <a href="https://github.com/CohumanSpace/digimon-engine/graphs/contributors">
-  <img src="https://contrib.rocks/image?repo=CohumanSpace/digimon-engine" />
+  <img src="https://contrib.rocks/image?repo=CohumanSpace/digimon-engine" alt="Contributors" />
 </a>
+
+Made with [contrib.rocks](https://contrib.rocks).


### PR DESCRIPTION
### What changes were proposed in this pull request?
Added alt text to the contributors image and attribution link to contrib.rocks in the README.md file.

### Why are the changes needed?
Improves accessibility for screen readers by adding alt text to the contributors image and properly attributes the source of the contributors visualization.

### Does this PR introduce _any_ user-facing change?
Yes, adds alt text for screen readers and visible attribution link in the README.md.

### How was this patch tested?
Verified the alt text is properly added to the image tag and the attribution link is correctly displayed in the README preview.